### PR TITLE
PAS-140: Update node version in build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,21 +13,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: 12
-            - name: Cache npm dependencies
-              uses: actions/cache@v1
-              with:
-                  key: npm-${{ hashFiles('package-lock.json') }}
-                  path: ~/.npm
-                  restore-keys: |
-                      npm-
+                  node-version: 18
+                  cache: 'npm'
+
             - name: Install dependencies
               run: npm ci --ignore-scripts --no-audit --no-progress
+
             - name: Lint
               run: npm run lint:ci
 
@@ -50,19 +46,13 @@ jobs:
         needs: [lint, typecheck]
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: 12
-            - name: Cache npm dependencies
-              uses: actions/cache@v1
-              with:
-                  key: npm-${{ hashFiles('package-lock.json') }}
-                  path: ~/.npm
-                  restore-keys: |
-                      npm-
+                  node-version: 18
+                  cache: 'npm'
             - name: Install dependencies
               run: npm ci --ignore-scripts --no-audit --no-progress
             - name: Build


### PR DESCRIPTION
- Update node version to 18 in build script
- Update action versions for checkout and node to latest
- Use setup-node cache instead of custom cache